### PR TITLE
Minor UI tweeks

### DIFF
--- a/app/Http/Controllers/ContractController.php
+++ b/app/Http/Controllers/ContractController.php
@@ -222,6 +222,7 @@ class ContractController extends BaseController
         $html = "<html>";
         $html .= "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">";
         $html .= "<body>";
+        $html .= "<h3>NOTICE: This contract's text was created automatically and may contain errors and differences from the contract's original PDF file. Learn more <a href=\"http://alpha.resourcecontracts.org/faqs\">here</a></h1>";
         $html .= $text;
         $html .= "</body>";
         $html .= "</html>";

--- a/public/css/contract-view.css
+++ b/public/css/contract-view.css
@@ -248,21 +248,26 @@
 .annotation-item {
     font-size: 12px;
     border: 0;
-    margin-bottom: 16px;
-    padding: 10px 20px 18px;
+    /*margin-bottom: 16px;*/
+    /*padding: 10px 20px 18px;*/
+    padding: 10px 20px 0;
 }
 
 .annotation-item .annotation-category-en {
     cursor: pointer;
     color: rgba(64,64,64,0.7);
-    padding: 0px;
+    padding: 10px 0 0 0;
     font-family: "open-sans-bold";
 }
 
 .annotation-item .annotation-category-fr {
-    padding: 0px;
+    padding: 0 0 10px;
     font-style: italic;
     margin: 4px 0;
+}
+
+.annotation-item .annotation-item-content, .annotation-item .annotation-item-page {
+    padding-left: 10px;
 }
 
 .annotation-item > span {
@@ -271,7 +276,7 @@
     line-height: 18px;
 }
 
-.annotation-item > span:first-child {
+.annotation-item .annotation-cluster {
     text-transform: uppercase;
     color: #404040;
     font-size: 13px;
@@ -280,11 +285,25 @@
     padding-bottom: 7px;
 }
 
-.annotation-item > span:first-child+span {
+.annotation-item > .annotation-cluster+span {
     border-top: 1px solid rgb(255,255,255);
     border-top: 1px solid rgba(255,255,255,0.3);
     padding-top: 7px;
 }
+./*annotation-item > span:first-child {
+    text-transform: uppercase;
+    color: #404040;
+    font-size: 13px;
+    border-bottom: 1px solid rgb(201,201,201);
+    border-bottom: 1px solid rgba(201,201,201,0.3);
+    padding-bottom: 7px;
+}*/
+
+/*.annotation-item > span:first-child+span {
+    border-top: 1px solid rgb(255,255,255);
+    border-top: 1px solid rgba(255,255,255,0.3);
+    padding-top: 7px;
+}*/
 
 .selected-annotation {
     border: 1px solid #C5C5C5;

--- a/public/css/contract-view.css
+++ b/public/css/contract-view.css
@@ -135,6 +135,7 @@
     cursor: pointer;
     text-indent: -9999px;
     display: block;
+    visibility: hidden;;
 }
 
 .metadata-shown span {

--- a/public/scripts/contract.view.custom/views/annotations.view.js
+++ b/public/scripts/contract.view.custom/views/annotations.view.js
@@ -151,15 +151,48 @@ var AnnotationItem = React.createClass({
                 showText = this.state.shortText;
             }
         }
-        return (
-            <div className={currentAnnotationClass} id={this.state.id}>
-                <span>{this.state.cluster}</span>
-                <span className="link annotation-category-en"><a href="#" onClick={this.handleAnnotationClick}>{this.state.categoryEn}</a></span>
-                <span className="link annotation-category-fr" onClick={this.handleAnnotationClick}>{this.state.categoryFr}</span>
-                <span className="link annotation-item-page" onClick={this.handleAnnotationClick}>Page: {this.state.pageNo}</span>
-                <span className="annotation-item-content" >{showText}<nobr><a className="annotation-item-ellipsis" href="#" onClick={this.handleEllipsis} dangerouslySetInnerHTML={{__html: ellipsistext}}></a></nobr></span>
-            </div>
-        );
+        if (this.props.prevAnnotation === undefined) {
+            return (
+                <div className={currentAnnotationClass} id={this.state.id}>
+                    <span className="header annotation-cluster">{this.state.cluster}</span>
+                    <span className="link annotation-category-en"><a href="#" onClick={this.handleAnnotationClick}>{this.state.categoryEn}</a></span>
+                    <span className="link annotation-category-fr" onClick={this.handleAnnotationClick}>{this.state.categoryFr}</span>
+                    <span className="annotation-item-content" >{showText}<nobr><a className="annotation-item-ellipsis" href="#" onClick={this.handleEllipsis} dangerouslySetInnerHTML={{__html: ellipsistext}}></a></nobr></span>
+                    <span className="link annotation-item-page" onClick={this.handleAnnotationClick}>Page: {this.state.pageNo}</span>
+                </div>
+            );
+        } else if (this.props.annotation.attributes.category_key !== this.props.prevAnnotation.attributes.category_key) {
+            return (
+                <div className={currentAnnotationClass} id={this.state.id}>
+                    <span className="link annotation-category-en"><a href="#" onClick={this.handleAnnotationClick}>{this.state.categoryEn}</a></span>
+                    <span className="link annotation-category-fr" onClick={this.handleAnnotationClick}>{this.state.categoryFr}</span>
+                    <span className="annotation-item-content" >{showText}<nobr><a className="annotation-item-ellipsis" href="#" onClick={this.handleEllipsis} dangerouslySetInnerHTML={{__html: ellipsistext}}></a></nobr></span>
+                    <span className="link annotation-item-page" onClick={this.handleAnnotationClick}>Page: {this.state.pageNo}</span>
+                </div>
+            );
+        } else if (this.props.annotation.attributes.text !== this.props.prevAnnotation.attributes.text) {
+            return (
+                <div className={currentAnnotationClass} id={this.state.id}>
+                    <span className="annotation-item-content" >{showText}<nobr><a className="annotation-item-ellipsis" href="#" onClick={this.handleEllipsis} dangerouslySetInnerHTML={{__html: ellipsistext}}></a></nobr></span>
+                    <span className="link annotation-item-page" onClick={this.handleAnnotationClick}>Page: {this.state.pageNo}</span>
+                </div>
+            );
+        } else {
+            return (
+                <div className={currentAnnotationClass} id={this.state.id}>
+                    <span className="link annotation-item-page" onClick={this.handleAnnotationClick}>Page: {this.state.pageNo}</span>
+                </div>
+            );
+        }
+        // return (
+        //     <div className={currentAnnotationClass} id={this.state.id}>
+        //         <span>{this.state.cluster}</span>
+        //         <span className="link annotation-category-en"><a href="#" onClick={this.handleAnnotationClick}>{this.state.categoryEn}</a></span>
+        //         <span className="link annotation-category-fr" onClick={this.handleAnnotationClick}>{this.state.categoryFr}</span>
+        //         <span className="annotation-item-content" >{showText}<nobr><a className="annotation-item-ellipsis" href="#" onClick={this.handleEllipsis} dangerouslySetInnerHTML={{__html: ellipsistext}}></a></nobr></span>
+        //         <span className="link annotation-item-page" onClick={this.handleAnnotationClick}>Page: {this.state.pageNo}</span>
+        //     </div>
+        // );
     }
 });
 
@@ -303,6 +336,7 @@ var AnnotationsList = React.createClass({
                 annotationsList.push((<AnnotationItem
                                 key={annotationsCollectionForList.models[i].get("id")}
                                 contractApp={this.props.contractApp}
+                                prevAnnotation={annotationsCollectionForList.models[i-1]}
                                 annotation={annotationsCollectionForList.models[i]} />
                                 ));
             }

--- a/public/scripts/contract.view.custom/views/annotations.view.js
+++ b/public/scripts/contract.view.custom/views/annotations.view.js
@@ -8,7 +8,7 @@ var AnnotationHeader = React.createClass({
     render: function() {
         var count = this.props.annotationsCollection.length;
         return (
-            <div className="annotation-title">Annotations - {count}</div>
+            <div className="annotation-title">{count} Annotations</div>
         );
     }
 });

--- a/public/scripts/contract.view.custom/views/annotations.view.js
+++ b/public/scripts/contract.view.custom/views/annotations.view.js
@@ -156,7 +156,7 @@ var AnnotationItem = React.createClass({
                 <span>{this.state.cluster}</span>
                 <span className="link annotation-category-en"><a href="#" onClick={this.handleAnnotationClick}>{this.state.categoryEn}</a></span>
                 <span className="link annotation-category-fr" onClick={this.handleAnnotationClick}>{this.state.categoryFr}</span>
-                <span className="link annotation-item-page" onClick={this.handleAnnotationClick}>#{this.state.pageNo}</span>
+                <span className="link annotation-item-page" onClick={this.handleAnnotationClick}>Page: {this.state.pageNo}</span>
                 <span className="annotation-item-content" >{showText}<a className="annotation-item-ellipsis" href="#" onClick={this.handleEllipsis} dangerouslySetInnerHTML={{__html: ellipsistext}}></a></span>
             </div>
         );

--- a/public/scripts/contract.view.custom/views/annotations.view.js
+++ b/public/scripts/contract.view.custom/views/annotations.view.js
@@ -145,9 +145,9 @@ var AnnotationItem = React.createClass({
         var showText = this.state.text;
         if(this.state.showEllipse) {
             showText = this.state.text;
-            ellipsistext = " ...less";
+            ellipsistext = " ... less";
             if(!this.state.showMoreFlag) {
-                ellipsistext = " ...more";
+                ellipsistext = " ... more";
                 showText = this.state.shortText;
             }
         }
@@ -157,7 +157,7 @@ var AnnotationItem = React.createClass({
                 <span className="link annotation-category-en"><a href="#" onClick={this.handleAnnotationClick}>{this.state.categoryEn}</a></span>
                 <span className="link annotation-category-fr" onClick={this.handleAnnotationClick}>{this.state.categoryFr}</span>
                 <span className="link annotation-item-page" onClick={this.handleAnnotationClick}>Page: {this.state.pageNo}</span>
-                <span className="annotation-item-content" >{showText}<a className="annotation-item-ellipsis" href="#" onClick={this.handleEllipsis} dangerouslySetInnerHTML={{__html: ellipsistext}}></a></span>
+                <span className="annotation-item-content" >{showText}<nobr><a className="annotation-item-ellipsis" href="#" onClick={this.handleEllipsis} dangerouslySetInnerHTML={{__html: ellipsistext}}></a></nobr></span>
             </div>
         );
     }

--- a/resources/views/contract/detail.blade.php
+++ b/resources/views/contract/detail.blade.php
@@ -369,8 +369,9 @@
                                 </div>
 
                                     @foreach($categories as $category => $annotations)
-                                    <div id="{{$category}}" class="sub-category">
-                                        {{ str_limit($category, $limit = 150, $end = '...') }}
+                                    <div id="{{str_slug($category,'-')}}" class="sub-category">
+                                        <a href="#{{str_slug($category,'-')}}"><i class='glyphicon glyphicon-link' style="visibility: hidden;"></i></a>
+                                        {{$category}}
                                     </div>
                                     <ul class="row">
                                     @foreach($annotations as $annotation)

--- a/resources/views/contract/detail.blade.php
+++ b/resources/views/contract/detail.blade.php
@@ -369,8 +369,8 @@
                                 </div>
 
                                     @foreach($categories as $category => $annotations)
-                                    <div class="sub-category">
-                                        {{$category}}
+                                    <div id="{{$category}}" class="sub-category">
+                                        {{ str_limit($category, $limit = 150, $end = '...') }}
                                     </div>
                                     <ul class="row">
                                     @foreach($annotations as $annotation)

--- a/resources/views/contract/partials/contractlist.blade.php
+++ b/resources/views/contract/partials/contractlist.blade.php
@@ -84,7 +84,13 @@
 
                     {{@trans('country')[$contract->country_code]}}
                 </td>
+            @else
+                <td></td>
+            @endif
+            @if($contract->signature_year !='')
                 <td>{{$contract->signature_year}}</td>
+            @else
+                <td></td>
             @endif
             <td>
                 <ul>


### PR DESCRIPTION
- added "Page: " label to annotatoins
- Added error handling to search results
- metadata toggle button hidden
- word doc has disclaimer added at beginning
- added space after elipses
- added anchor links to annotation divs at bottom of contract detail page and fixed link buttons at top
- Added something in annotions.view.js to deal with repeating categories and clusters (old code and css is commented)
