### PR TITLE
1148 fix errors from logs

### DIFF
--- a/app/Http/Services/APIService.php
+++ b/app/Http/Services/APIService.php
@@ -337,6 +337,7 @@ class APIService
                     Cache::put($key, $data, Carbon::now()->addMinutes(5));
                 }else {
                     Log::error("API call to:".$request->getUrl()." returned status code ".$statusCode);
+                    Log::error("Response body of the API call ".$request->getUrl()." was ".$data);
                 }
             }
 

--- a/app/Http/Services/APIService.php
+++ b/app/Http/Services/APIService.php
@@ -332,7 +332,12 @@ class APIService
                 $response = $this->client->send($request);
                 $data     = $response->getBody();
                 $data     = $data->getContents();
-                Cache::put($key, $data, Carbon::now()->addMinutes(5));
+                $statusCode = $response->getStatusCode();
+                if ($statusCode == 200) {
+                    Cache::put($key, $data, Carbon::now()->addMinutes(5));
+                }else {
+                    Log::error("API call to:".$request->getUrl()." returned status code ".$statusCode);
+                }
             }
 
             if ($array) {
@@ -460,6 +465,7 @@ class APIService
     {
         $summaries = $this->summary();
         $data      = [];
+
         foreach ($summaries->country_summary as $summary) {
 
             $data[trans('country.'.strtoupper($summary->key))] = [

--- a/config/nginx_subsite.template
+++ b/config/nginx_subsite.template
@@ -2,18 +2,6 @@
 server {
   server_name ${SERVER_NAME};
 
-  if ($http_x_forwarded_proto != 'https' ) {
-    set $redirect_https 1;
-  }
-  if ( $request_uri = '/health' ) {
-      set $redirect_https 0;
-  }
-
-  if ( $redirect_https = 1){
-    return 301 https://$host$request_uri;
-  }
-
-
   root        /var/www/${CATEGORY}/public;
   index       index.php;
 

--- a/config/nginx_subsite_protected.template
+++ b/config/nginx_subsite_protected.template
@@ -1,7 +1,4 @@
 server {
-  if ($http_x_forwarded_proto != 'https' ) {
-    return 301 https://$host$request_uri;
-  }
 
   server_name ${SERVER_NAME};
   root        /var/www/${CATEGORY}/public;


### PR DESCRIPTION
- No longer caching result from the API if status code of the request is not 200.
- Removed redirect to HTTPS as it has been done through AWS ALB.

The actual exceptions has not been fixed, the source of them needs to be fixed in RC API.