### PR TITLE
Caching response from API even if it is an error

### DIFF
--- a/app/Http/Services/APIService.php
+++ b/app/Http/Services/APIService.php
@@ -336,6 +336,7 @@ class APIService
                 if ($statusCode == 200) {
                     Cache::put($key, $data, Carbon::now()->addMinutes(5));
                 }else {
+                    Cache::put($key, $data, Carbon::now()->addMinutes(5));
                     Log::error("API call to:".$request->getUrl()." returned status code ".$statusCode);
                     Log::error("Response body of the API call ".$request->getUrl()." was ".$data);
                 }


### PR DESCRIPTION
Caching API response if error is returned to put less pressure on the API.