### PR TITLE
1204 fix error when path parameter sortby used without order

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tests"
   },
   "dependencies": {
-    "axios": "^0.15.3",
+    "axios": "^0.18.1",
     "babel-core": "^6.9.1",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.9.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
     "gulp-uglifycss": "^1.0.6",
-    "jquery": "^1.9.1",
+    "jquery": "^3.4.0",
     "js-cookie": "^2.1.3",
     "lodash": "^4.17.11",
     "react": "^15.1.0",

--- a/resources/views/contract/partials/contract_list.blade.php
+++ b/resources/views/contract/partials/contract_list.blade.php
@@ -72,11 +72,13 @@ if ($path[0] == "resource") {
                 <td>
                     <?php
                     if (isset($url['sortby']) && $url['sortby'] == "resource") {
-                        if ($url['order'] == "asc") {
-                            asort($contract->resource);
-                        }
-                        if ($url['order'] == "desc") {
-                            rsort($contract->resource);
+                        if (isset($url['order'])){
+                            if ($url['order'] == "asc") {
+                                asort($contract->resource);
+                            }
+                            if ($url['order'] == "desc") {
+                                rsort($contract->resource);
+                            }
                         }
                     }
                     ?>


### PR DESCRIPTION
## Why 
When accessing a contracts or a country page using the `sortby` parameter without the `order` parameter, an error page is displayed.

## What 
- [x] Fix the issue

## Note
The pull request also contains some library upgrades that were marked by github as security issues.
This is a fix for https://github.com/NRGI/resourcecontracts.org/issues/1204
https://resourcecontracts.org/countries/az?sortby=resource
<img width="929" alt="Screenshot 2019-07-16 at 19 21 49" src="https://user-images.githubusercontent.com/3942821/61311426-ff674300-a7fe-11e9-95f3-a21e106330fc.png">
