### PR TITLE
Disallow crawling of search and sorted pages

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,8 @@
+User-agent: *
+
+Disallow: /search
+Disallow: /search/group
+Disallow: /search*
+
+Disallow: /*all=1*
+Disallow: /*sortby=*


### PR DESCRIPTION
https://github.com/NRGI/resourcecontracts.org/issues/1324

Search pages and sorted pages are referenced from the site with html links which allows bots to crawl them. Since they only contain duplicate content there's no reason to allow crawling.