### PR TITLE
1326 javascript sort buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ bourbon
 !spec/*.map
 /public/[0-9]*
 *.lock
+
+.docker-compose.env
+docker-compose.yml

--- a/app/Helper/Helper.php
+++ b/app/Helper/Helper.php
@@ -144,6 +144,22 @@ function appendInUrl($route, $url, $sortby, $order)
 }
 
 /**
+ * Builds the query string needed to sort by the given sort criteria and order starting from an existing url and query
+ * parameters.
+ *
+ * @param $route string the path of the page to sort without the host part
+ * @param $url array dictionary of existing query parameters
+ * @param $sortby string sort criteria
+ * @param $order string sort order
+ * @return string the query string needed to sort the given page with the given sort criteria
+ */
+function getSortQuery($route, $url, $sortby, $order)
+{
+    $location = appendInUrl($route, $url, $sortby, $order);
+    return parse_url($location)['query'];
+}
+
+/**
  * Show array icon
  *
  * @param      $order

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,8 +1,8 @@
 User-agent: *
 
 Disallow: /search
-Disallow: /search/group
-Disallow: /search*
+Allow: /search/group$
 
 Disallow: /*all=1*
 Disallow: /*sortby=*
+Disallow: /*?q=1*

--- a/resources/views/contract/partials/contract_list.blade.php
+++ b/resources/views/contract/partials/contract_list.blade.php
@@ -3,6 +3,7 @@ $url = Request::all();
 $order = \Illuminate\Support\Facades\Input::get('order', '');
 $sortBy = \Illuminate\Support\Facades\Input::get('sortby', '');
 $path = Request::path();
+$full_path = $path;
 $path = explode('/', $path);
 $url['key'] = $path[1];
 $route = "country.detail";
@@ -14,15 +15,31 @@ if ($path[0] == "resource") {
     <thead>
     <th></th>
     <th>
-        <a href="{{appendInUrl($route,$url,"contract_name",$order)}}">@lang('global.document'){!!show_arrow($order, $sortBy=='contract_name')!!}</a>
+        <a href="javascript:void(0)" onClick="window.location.href = '{{url($full_path)}}' + '?' + '{{getSortQuery($route,$url,"contract_name",$order)}}'; return false;">
+            @lang('global.document')
+            {!!show_arrow($order, $sortBy=='contract_name')!!}
+        </a>
     </th>
     <th></th>
-    <th width="10%"><a href="{{appendInUrl($route,$url,"year",$order)}}">@lang('global.year') {!!show_arrow($order, $sortBy=='year')!!}</a></th>
+    <th width="10%">
+        <a href="javascript:void(0)" onClick="window.location.href = '{{url($full_path)}}' + '?' + '{{getSortQuery($route,$url,"year",$order)}}'; return false;">
+            @lang('global.year')
+            {!!show_arrow($order, $sortBy=='year')!!}
+        </a>
+    </th>
 
     <th>
-        <a href="{{appendInUrl($route,$url,"resource",$order)}}">@lang('global.resource') {!!show_arrow($order, $sortBy=='resource')!!}</a>
+        <a href="javascript:void(0)" onClick="window.location.href = '{{url($full_path)}}' + '?' + '{{getSortQuery($route,$url,"resource",$order)}}'; return false;">
+            @lang('global.resource')
+            {!!show_arrow($order, $sortBy=='resource')!!}
+        </a>
     </th>
-    <th><a href="{{appendInUrl($route,$url,"contract_type",$order)}}">@lang('global.contract_type'){!!show_arrow($order, $sortBy=='contract_type')!!}</a></th>
+    <th>
+        <a href="javascript:void(0)" onClick="window.location.href = '{{url($full_path)}}' + '?' + '{{getSortQuery($route,$url,"contract_type",$order)}}'; return false;">
+            @lang('global.contract_type')
+            {!!show_arrow($order, $sortBy=='contract_type')!!}
+        </a>
+    </th>
     </thead>
     <tbody>
     @if(isset($contracts->results))

--- a/resources/views/contract/partials/group_search_list.blade.php
+++ b/resources/views/contract/partials/group_search_list.blade.php
@@ -10,34 +10,36 @@ $api = app('App\Http\Services\APIService');
 <table class="table table-responsive table-contract table-contract-list">
 	<thead>
 	<th width="50%">
-		<a href="{{appendInUrl($route,$filter_params,"contract_name",$orderBy)}}">@lang('global.document')
-			{!!show_arrow
-		($orderBy,
-			$sortBy=='contract_name')!!}</a>
+        <a href="javascript:void(0)" onClick="window.location.href = '{{url($path)}}' + '?' + '{{getSortQuery($route,$filter_params,"contract_name",$order)}}'; return false;">
+            @lang('global.document')
+			{!!show_arrow($orderBy,$sortBy=='contract_name')!!}
+        </a>
 	</th>
 	<th></th>
 	@if(!site()->isCountrySite())
-		<th width="12%"><a href="{{appendInUrl($route,$filter_params,"country",$orderBy)}}">@lang('global.country')
-				{!!show_arrow
-				($orderBy, $sortBy=='country')!!}</a>
+		<th width="12%">
+            <a href="javascript:void(0)" onClick="window.location.href = '{{url($path)}}' + '?' + '{{getSortQuery($route,$filter_params,"country",$order)}}'; return false;">
+                @lang('global.country')
+                {!!show_arrow($orderBy, $sortBy=='country')!!}
+            </a>
 		</th>
 	@endif
 	@if($showYear)
 		<th>
-			<a href="{{appendInUrl($route,$filter_params,"year",$orderBy)}}">
+            <a href="javascript:void(0)" onClick="window.location.href = '{{url($path)}}' + '?' + '{{getSortQuery($route,$filter_params,"year",$order)}}'; return false;">
 				@lang('global.year')
 				{!!show_arrow($orderBy, $sortBy=='year')!!}
 			</a>
 		</th>
 	@endif
 	<th width="13%">
-		<a href="{{appendInUrl($route,$filter_params,"resource",$orderBy)}}">
+        <a href="javascript:void(0)" onClick="window.location.href = '{{url($path)}}' + '?' + '{{getSortQuery($route,$filter_params,"resource",$order)}}'; return false;">
 			@lang('global.resource')
 			{!!show_arrow($orderBy, $sortBy=='resource')!!}
 		</a>
 	</th>
 	<th width="25%">
-		<a href="{{appendInUrl($route,$filter_params,"contract_type",$orderBy)}}">
+        <a href="javascript:void(0)" onClick="window.location.href = '{{url($path)}}' + '?' + '{{getSortQuery($route,$filter_params,"contract_type",$order)}}'; return false;">
 			@lang('contract.contract_type')
 			{!!show_arrow($orderBy, $sortBy=='contract_type')!!}
 		</a>

--- a/resources/views/contract/partials/group_search_list.blade.php
+++ b/resources/views/contract/partials/group_search_list.blade.php
@@ -10,7 +10,7 @@ $api = app('App\Http\Services\APIService');
 <table class="table table-responsive table-contract table-contract-list">
 	<thead>
 	<th width="50%">
-        <a href="javascript:void(0)" onClick="window.location.href = '{{url($path)}}' + '?' + '{{getSortQuery($route,$filter_params,"contract_name",$order)}}'; return false;">
+        <a href="javascript:void(0)" onClick="window.location.href = '{{url($path)}}' + '?' + '{{getSortQuery($route,$filter_params,"contract_name",$orderBy)}}'; return false;">
             @lang('global.document')
 			{!!show_arrow($orderBy,$sortBy=='contract_name')!!}
         </a>
@@ -18,7 +18,7 @@ $api = app('App\Http\Services\APIService');
 	<th></th>
 	@if(!site()->isCountrySite())
 		<th width="12%">
-            <a href="javascript:void(0)" onClick="window.location.href = '{{url($path)}}' + '?' + '{{getSortQuery($route,$filter_params,"country",$order)}}'; return false;">
+            <a href="javascript:void(0)" onClick="window.location.href = '{{url($path)}}' + '?' + '{{getSortQuery($route,$filter_params,"country",$orderBy)}}'; return false;">
                 @lang('global.country')
                 {!!show_arrow($orderBy, $sortBy=='country')!!}
             </a>
@@ -26,20 +26,20 @@ $api = app('App\Http\Services\APIService');
 	@endif
 	@if($showYear)
 		<th>
-            <a href="javascript:void(0)" onClick="window.location.href = '{{url($path)}}' + '?' + '{{getSortQuery($route,$filter_params,"year",$order)}}'; return false;">
+            <a href="javascript:void(0)" onClick="window.location.href = '{{url($path)}}' + '?' + '{{getSortQuery($route,$filter_params,"year",$orderBy)}}'; return false;">
 				@lang('global.year')
 				{!!show_arrow($orderBy, $sortBy=='year')!!}
 			</a>
 		</th>
 	@endif
 	<th width="13%">
-        <a href="javascript:void(0)" onClick="window.location.href = '{{url($path)}}' + '?' + '{{getSortQuery($route,$filter_params,"resource",$order)}}'; return false;">
+        <a href="javascript:void(0)" onClick="window.location.href = '{{url($path)}}' + '?' + '{{getSortQuery($route,$filter_params,"resource",$orderBy)}}'; return false;">
 			@lang('global.resource')
 			{!!show_arrow($orderBy, $sortBy=='resource')!!}
 		</a>
 	</th>
 	<th width="25%">
-        <a href="javascript:void(0)" onClick="window.location.href = '{{url($path)}}' + '?' + '{{getSortQuery($route,$filter_params,"contract_type",$order)}}'; return false;">
+        <a href="javascript:void(0)" onClick="window.location.href = '{{url($path)}}' + '?' + '{{getSortQuery($route,$filter_params,"contract_type",$orderBy)}}'; return false;">
 			@lang('contract.contract_type')
 			{!!show_arrow($orderBy, $sortBy=='contract_type')!!}
 		</a>

--- a/resources/views/contract/partials/pagination.blade.php
+++ b/resources/views/contract/partials/pagination.blade.php
@@ -5,6 +5,8 @@ $no_of_pages = 6;
 $current_url = \Illuminate\Support\Facades\Input::url();
 $queries     = \Illuminate\Support\Facades\Input::get();
 $queries = array_except($queries,['page']);
+$page_url = \Illuminate\Support\Facades\Input::url();
+$queries_with_all = http_build_query(array_merge($queries, ['all' => '1']));
 $current_url .= "?";
 $current_url .= (http_build_query($queries) == '') ? '' : http_build_query($queries) . '&';
 ?>
@@ -48,7 +50,8 @@ $current_url .= (http_build_query($queries) == '') ? '' : http_build_query($quer
                     </li>
                     <li class="num-text"><a href="{{ $current_url }}page={{ $total_page }}">@lang('global.last')</a></li>
                     @if (!Request::is('search/group'))
-                        <li class="num-text"><a href="{{ $current_url }}all={{true}}">@lang('global.view_all')</a></li>
+
+                <li class="num-text"><a href="javascript:void(0)" onClick="window.location.href = '{{$page_url}}' + '?' + '{{$queries_with_all}}'; return false;">@lang('global.view_all')</a></li>
                     @endif
                 @endif
             </ul>

--- a/resources/views/contract/partials/search_list.blade.php
+++ b/resources/views/contract/partials/search_list.blade.php
@@ -18,30 +18,36 @@ if ($route == "contracts" && isset($url['year'])) {
 <table class="table table-responsive table-contract table-contract-list">
     <thead>
     <th width="50%">
-        <a href="{{appendInUrl($route,$url,"contract_name",$order)}}">@lang('global.document') {!!show_arrow($order, $sortBy=='contract_name')!!}</a>
+        <a href="javascript:void(0)" onClick="window.location.href = '{{url($path)}}' + '?' + '{{getSortQuery($route,$url,"contract_name",$order)}}'; return false;">
+            @lang('global.document')
+            {!!show_arrow($order, $sortBy=='contract_name')!!}
+        </a>
     </th>
     <th></th>
     @if(!site()->isCountrySite())
-        <th width="12%"><a href="{{appendInUrl($route,$url,"country",$order)}}">@lang('global.country') {!!show_arrow
-					($order, $sortBy=='country')!!}</a>
+        <th width="12%">
+            <a href="javascript:void(0)" onClick="window.location.href = '{{url($path)}}' + '?' + '{{getSortQuery($route,$url,"country",$order)}}'; return false;">
+                @lang('global.country')
+                {!!show_arrow($order, $sortBy=='country')!!}
+            </a>
         </th>
     @endif
     @if($showYear)
         <th>
-            <a href="{{appendInUrl($route,$url,"year",$order)}}">
+            <a href="javascript:void(0)" onClick="window.location.href = '{{url($path)}}' + '?' + '{{getSortQuery($route,$url,"year",$order)}}'; return false;">
                 @lang('global.year')
                 {!!show_arrow($order, $sortBy=='year')!!}
             </a>
         </th>
     @endif
     <th width="13%">
-        <a href="{{appendInUrl($route,$url,"resource",$order)}}">
+        <a href="javascript:void(0)" onClick="window.location.href = '{{url($path)}}' + '?' + '{{getSortQuery($route,$url,"resource",$order)}}'; return false;">
             @lang('global.resource')
             {!!show_arrow($order, $sortBy=='resource')!!}
         </a>
     </th>
     <th width="25%">
-        <a href="{{appendInUrl($route,$url,"contract_type",$order)}}">
+        <a href="javascript:void(0)" onClick="window.location.href = '{{url($path)}}' + '?' + '{{getSortQuery($route,$url,"contract_type",$order)}}'; return false;">
             @lang('contract.contract_type')
             {!!show_arrow($order, $sortBy=='contract_type')!!}
         </a>


### PR DESCRIPTION
Use JavaScript obfuscates the urls used by the  sort and `View All` buttons on contract listings and search pages so that web crawlers won't follow them.

Hopefully this will reduce traffic from web crawlers that do not fully respect the robots.txt file.